### PR TITLE
Make datatable `dat` scrollable in vignette

### DIFF
--- a/vignettes/tut_01.Rmd
+++ b/vignettes/tut_01.Rmd
@@ -106,7 +106,7 @@ he = strsplit(readLines(dir(od, full=TRUE, patt="head"), warn=FALSE), ";")[[1]]
 dat = read.delim(fi, sep=";", h=FALSE)
 names(dat) = he
 library(DT)
-datatable(dat)
+datatable(dat, options = list(scrollX = TRUE))
 ```
 
 


### PR DESCRIPTION
This PR is an attempt to make the table `dat` scrollable on the article - https://vjcitn.github.io/biocBiocypher/articles/tut_01.html